### PR TITLE
Only find-rel elements are allowed in client find-spec

### DIFF
--- a/src/com/wsscode/pathom/connect/datomic.clj
+++ b/src/com/wsscode/pathom/connect/datomic.clj
@@ -33,7 +33,7 @@
               [_ :db.install/attribute ?e]
               [?e :db/ident ?ident]]
          db)
-       flatten
+       (map first)
        (reduce
          (fn [schema entry]
            (assoc schema (:db/ident entry) entry))
@@ -224,7 +224,7 @@
   like `:not-in/datomic`."
   [{::keys [db] :as env} dquery]
   (let [subquery (entity-subquery env)]
-    (flatten
+    (map first
      (raw-datomic-q env (assoc dquery :find [[(list 'pull '?e (inject-ident-subqueries env subquery))]])
        db))))
 


### PR DESCRIPTION
I've been testing this using the Client API, and was running into this exception:

```
ExceptionInfo Only find-rel elements are allowed in client find-spec
```

Apparently `'.` and `'...` are not supported by Datomic's Client API in `:find` expressions 😕

The fix here is the shortest path to working I could find, I can't speak to its efficiency. It _should_ work in both on-prem and client cases tho (lowest common denominator).

Cheers