### PR TITLE
Lazy load datomic on-prem dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  ["src"]
 
  :deps
- {com.wsscode/pathom  {:mvn/version "2.2.25"}
+ {com.wsscode/pathom  {:mvn/version "2.3.0-alpha4"}
   org.slf4j/slf4j-api {:mvn/version "1.7.30"}}
 
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -10,8 +10,10 @@
   {:extra-deps {org.clojure/clojure {:mvn/version "1.10.1"}}}
 
   :dev
-  {:extra-deps {com.datomic/datomic-free       {:mvn/version "0.9.5703.21"}
-                ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}}
+  {:extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}}
+
+  :on-prem
+  {:extra-deps {com.datomic/datomic-free       {:mvn/version "0.9.5703.21"}}}
 
   :test
   {:extra-paths ["test"]

--- a/src/com/wsscode/pathom/connect/datomic/on_prem.clj
+++ b/src/com/wsscode/pathom/connect/datomic/on_prem.clj
@@ -1,6 +1,11 @@
-(ns com.wsscode.pathom.connect.datomic.on-prem
-  (:require [datomic.api :as d]))
+(ns com.wsscode.pathom.connect.datomic.on-prem)
+
+(defn- lazily [sym]
+  (let [f-thunk (delay (require (symbol (namespace sym)))
+                       (resolve sym))]
+    (fn [& args]
+      (apply @f-thunk args))))
 
 (def on-prem-config
-  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  d/q
-   :com.wsscode.pathom.connect.datomic/datomic-driver-db d/db})
+  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  (lazily 'datomic.api/q)
+   :com.wsscode.pathom.connect.datomic/datomic-driver-db (lazily 'datomic.api/db)})


### PR DESCRIPTION
This PR suggest two orthogonal changes, that can be accepted or rejected individually.

1. Lazy-load the `datomic.api` dependency from the `com.wsscode.pathom.connect.datomic.on-prem` namespace. This allows loading the namespace even when the datomic on-prem lib is not available in the client classpath, which will be the case for datomic-client/datomic-cloud users. This makes pathom-datomic more friendly for tools.namespace refresh users, as well as any other tool that scans the entire classpath.

2. Depend on datomic-free from a different alias, to allow datomic client users to develop this library as well. This change does not affect transitive dependencies, so it's just a dev time convenience.