### PR TITLE
Update sample code to solve for `reader2` error

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -74,7 +74,7 @@ Example setup:
 (def parser
   (p/parser
     {::p/env     {::p/reader               [p/map-reader
-                                            pc/reader2
+                                            pc/reader3
                                             pc/open-ident-reader
                                             p/env-placeholder-reader]
                   ::p/placeholder-prefixes #{">"}}


### PR DESCRIPTION
Updating the sample code to use `reader3`, which works fine where `reader2` does not 😅

See #10