### PR TITLE
Add support for Datomic Pull back navigation

### DIFF
--- a/src/com/wsscode/pathom/connect/datomic.clj
+++ b/src/com/wsscode/pathom/connect/datomic.clj
@@ -25,6 +25,7 @@
     :req [:db/ident :db/id :db/valueType :db/cardinality]
     :opt [:db/doc :db/unique]))
 
+(s/def :db/ident keyword?)
 (s/def ::schema (s/map-of :db/ident ::schema-entry))
 
 (defn raw-datomic-q [{::keys [datomic-driver-q]} & args]


### PR DESCRIPTION
Hello! 

This is a first iteration of adding support for back navigation.

Todo:
- [ ] Refactoring
- [ ] Restrain where it's allowed (it's very liberal as to where back navs are a allowed)
- [ ] Tests

Note: Also fixed bug in regex filtering of built-in DB idents (now in `is-db-ident?`). Previously it would filter out things like `dbug/id` or `dbs.hello/world` since they start with `db`.