### PR TITLE
Add spec for :db/ident

### DIFF
--- a/src/com/wsscode/pathom/connect/datomic.clj
+++ b/src/com/wsscode/pathom/connect/datomic.clj
@@ -25,6 +25,7 @@
     :req [:db/ident :db/id :db/valueType :db/cardinality]
     :opt [:db/doc :db/unique]))
 
+(s/def :db/ident keyword?)
 (s/def ::schema (s/map-of :db/ident ::schema-entry))
 
 (defn raw-datomic-q [{::keys [datomic-driver-q]} & args]


### PR DESCRIPTION
A spec for `:db/ident` was missing.