### PR TITLE
Lazy Load Datomic Client API

### DIFF
--- a/src/com/wsscode/pathom/connect/datomic/client.clj
+++ b/src/com/wsscode/pathom/connect/datomic/client.clj
@@ -1,6 +1,6 @@
 (ns com.wsscode.pathom.connect.datomic.client
-  (:require [datomic.client.api :as d]))
+  (:require [com.wsscode.pathom.connect.datomic.helper :as helper]))
 
 (def client-config
-  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  d/q
-   :com.wsscode.pathom.connect.datomic/datomic-driver-db d/db})
+  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  (helper/lazily 'datomic.client.api/q)
+   :com.wsscode.pathom.connect.datomic/datomic-driver-db (helper/lazily 'datomic.client.api/db)})

--- a/src/com/wsscode/pathom/connect/datomic/helper.clj
+++ b/src/com/wsscode/pathom/connect/datomic/helper.clj
@@ -1,0 +1,7 @@
+(ns com.wsscode.pathom.connect.datomic.helper)
+
+(defn lazily [sym]
+  (let [f-thunk (delay (require (symbol (namespace sym)))
+                       (resolve sym))]
+    (fn [& args]
+      (apply @f-thunk args))))

--- a/src/com/wsscode/pathom/connect/datomic/on_prem.clj
+++ b/src/com/wsscode/pathom/connect/datomic/on_prem.clj
@@ -1,11 +1,6 @@
-(ns com.wsscode.pathom.connect.datomic.on-prem)
-
-(defn- lazily [sym]
-  (let [f-thunk (delay (require (symbol (namespace sym)))
-                       (resolve sym))]
-    (fn [& args]
-      (apply @f-thunk args))))
+(ns com.wsscode.pathom.connect.datomic.on-prem
+  (:require [com.wsscode.pathom.connect.datomic.helper :as helper]))
 
 (def on-prem-config
-  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  (lazily 'datomic.api/q)
-   :com.wsscode.pathom.connect.datomic/datomic-driver-db (lazily 'datomic.api/db)})
+  {:com.wsscode.pathom.connect.datomic/datomic-driver-q  (helper/lazily 'datomic.api/q)
+   :com.wsscode.pathom.connect.datomic/datomic-driver-db (helper/lazily 'datomic.api/db)})


### PR DESCRIPTION
Hi @wilkerlucio,

I have a project that is using pathom-datomic, which only has the
Datomic On-Prem JAR on the classpath. When I reload the project
with tools.namespace, it tries to reload the
`com.wsscode.pathom.connect.datomic.client` namespace and fails
with an exception about `datomic.client.api` not beeing on the
classpath.

I saw that the on-prem namespace lazy loads it's dependency. This
PR changes the client api namespace to use the same lazy loading
approach as the on-prem namespace to avoid this issue.

I think pathom-datomic3 uses the same code as pathom-datomic, so
I believe we might have the same problem there. If you accept
this PR, I can open one there as well if you like.

This is the exception:

```
2. Unhandled java.io.FileNotFoundException
   Could not locate datomic/client/api__init.class,
   datomic/client/api.clj or datomic/client/api.cljc on classpath.

                   RT.java:  462  clojure.lang.RT/load
                   RT.java:  424  clojure.lang.RT/load
                  core.clj: 6161  clojure.core/load/fn
                  core.clj: 6160  clojure.core/load
                  core.clj: 6144  clojure.core/load
               RestFn.java:  408  clojure.lang.RestFn/invoke
                  core.clj: 5933  clojure.core/load-one
                  core.clj: 5928  clojure.core/load-one
                  core.clj: 5975  clojure.core/load-lib/fn
                  core.clj: 5974  clojure.core/load-lib
                  core.clj: 5953  clojure.core/load-lib
               RestFn.java:  142  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6016  clojure.core/load-libs
                  core.clj: 6000  clojure.core/load-libs
               RestFn.java:  137  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6038  clojure.core/require
                  core.clj: 6038  clojure.core/require
               RestFn.java:  408  clojure.lang.RestFn/invoke
                client.clj:    1  com.wsscode.pathom.connect.datomic.client/eval68704/loading--auto--
                client.clj:    1  com.wsscode.pathom.connect.datomic.client/eval68704
                client.clj:    1  com.wsscode.pathom.connect.datomic.client/eval68704
             Compiler.java: 7194  clojure.lang.Compiler/eval
             Compiler.java: 7183  clojure.lang.Compiler/eval
             Compiler.java: 7653  clojure.lang.Compiler/load
                   RT.java:  381  clojure.lang.RT/loadResourceScript
                   RT.java:  372  clojure.lang.RT/loadResourceScript
                   RT.java:  459  clojure.lang.RT/load
                   RT.java:  424  clojure.lang.RT/load
                  core.clj: 6161  clojure.core/load/fn
                  core.clj: 6160  clojure.core/load
                  core.clj: 6144  clojure.core/load
               RestFn.java:  408  clojure.lang.RestFn/invoke
                  core.clj: 5933  clojure.core/load-one
                  core.clj: 5928  clojure.core/load-one
                  core.clj: 5975  clojure.core/load-lib/fn
                  core.clj: 5974  clojure.core/load-lib
                  core.clj: 5953  clojure.core/load-lib
               RestFn.java:  142  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6016  clojure.core/load-libs
                  core.clj: 6000  clojure.core/load-libs
               RestFn.java:  137  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6038  clojure.core/require
                  core.clj: 6038  clojure.core/require
               RestFn.java:  421  clojure.lang.RestFn/invoke
                reload.clj:   32  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload-one
                reload.clj:   18  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload-one
                reload.clj:   49  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload
                reload.clj:   40  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload
               refresh.clj:  171  cider.nrepl.middleware.refresh/refresh-reply/fn/fn
               refresh.clj:  161  cider.nrepl.middleware.refresh/refresh-reply/fn
                  AFn.java:   22  clojure.lang.AFn/run
               session.clj:  218  nrepl.middleware.session/session-exec/main-loop/fn
               session.clj:  217  nrepl.middleware.session/session-exec/main-loop
                  AFn.java:   22  clojure.lang.AFn/run
               Thread.java:  829  java.lang.Thread/run

1. Caused by clojure.lang.Compiler$CompilerException
   Error compiling com/wsscode/pathom/connect/datomic/client.clj at (1:1)
   {:clojure.error/phase :execution,
    :clojure.error/line 1,
    :clojure.error/column 1,
    :clojure.error/source
    "com/wsscode/pathom/connect/datomic/client.clj"}
             Compiler.java: 7665  clojure.lang.Compiler/load
                   RT.java:  381  clojure.lang.RT/loadResourceScript
                   RT.java:  372  clojure.lang.RT/loadResourceScript
                   RT.java:  459  clojure.lang.RT/load
                   RT.java:  424  clojure.lang.RT/load
                  core.clj: 6161  clojure.core/load/fn
                  core.clj: 6160  clojure.core/load
                  core.clj: 6144  clojure.core/load
               RestFn.java:  408  clojure.lang.RestFn/invoke
                  core.clj: 5933  clojure.core/load-one
                  core.clj: 5928  clojure.core/load-one
                  core.clj: 5975  clojure.core/load-lib/fn
                  core.clj: 5974  clojure.core/load-lib
                  core.clj: 5953  clojure.core/load-lib
               RestFn.java:  142  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6016  clojure.core/load-libs
                  core.clj: 6000  clojure.core/load-libs
               RestFn.java:  137  clojure.lang.RestFn/applyTo
                  core.clj:  669  clojure.core/apply
                  core.clj: 6038  clojure.core/require
                  core.clj: 6038  clojure.core/require
               RestFn.java:  421  clojure.lang.RestFn/invoke
                reload.clj:   32  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload-one
                reload.clj:   18  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload-one
                reload.clj:   49  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload
                reload.clj:   40  cider.nrepl.inlined-deps.toolsnamespace.v1v3v0.clojure.tools.namespace.reload/track-reload
               refresh.clj:  171  cider.nrepl.middleware.refresh/refresh-reply/fn/fn
               refresh.clj:  161  cider.nrepl.middleware.refresh/refresh-reply/fn
                  AFn.java:   22  clojure.lang.AFn/run
               session.clj:  218  nrepl.middleware.session/session-exec/main-loop/fn
               session.clj:  217  nrepl.middleware.session/session-exec/main-loop
                  AFn.java:   22  clojure.lang.AFn/run
               Thread.java:  829  java.lang.Thread/run
```

